### PR TITLE
Filled out br0 config in README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ auto br0
 iface br0 inet static
       address 192.168.1.4
       netmask 255.255.255.0
+      network 192.168.1.0
+      broadcast 192.168.1.255
+      gateway 192.168.1.1
       bridge_ports eth0
       bridge_stp off
       bridge_fd 0


### PR DESCRIPTION
Added some more config info to br0 setup in `/etc/network/interfaces' file for those that cut and paste verbatim (guilty here). Failure to include broadcast, gateway, and network broke internet on the host. Now br0 is fully functional when host is rebooted.
