### PR TITLE
Update debian version to stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM stackbrew/debian:jessie
 ENV ARCH amd64
-ENV DIST wheezy
+ENV DIST stretch
 ENV MIRROR http://ftp.nl.debian.org
 RUN apt-get -q update
 RUN apt-get -qy install dnsmasq wget iptables


### PR DESCRIPTION
Stretch has been the stable debian version for almost a year. [1](https://www.debian.org/News/2017/20170617)